### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generate-apk-aab-debug-release.yml
+++ b/.github/workflows/generate-apk-aab-debug-release.yml
@@ -1,5 +1,8 @@
 name: Generated APK AAB (Upload - Create Artifact To Github Action)
 
+permissions:
+  contents: read
+
 env:
   # The name of the main module repository
   main_project_module: app


### PR DESCRIPTION
Potential fix for [https://github.com/hawjo01/GameScore/security/code-scanning/1](https://github.com/hawjo01/GameScore/security/code-scanning/1)

To resolve the issue, add an explicit `permissions:` block at the root of the workflow YAML file, specifying minimal necessary permissions. For artifact upload workflows that do not modify repository content or interact with issues, the recommended permission is `contents: read`. Place the following near the top (immediately after `name:` and before `env:`, or directly after `env:`) in `.github/workflows/generate-apk-aab-debug-release.yml`:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are required, as this is a declarative configuration change in the YAML workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
