### PR TITLE
Revert upgrade of kotlin.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.13.2"
-kotlin = "2.3.0"
+kotlin = "2.2.21"
 coreKtx = "1.17.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"


### PR DESCRIPTION
Version 2.3.0 of kotlin is not supported by github codeql analysis and
this upgrade caused some problems with ksp/kapt.  Reverting this upgrade
and will try a future update.
